### PR TITLE
Add nostr-verified.wellorder.net relay

### DIFF
--- a/main.js
+++ b/main.js
@@ -15,7 +15,8 @@ const App = {
         'wss://nostr-relay.wlvs.space',
         'wss://nostr.onsats.org',
         'wss://nostr-relay.untethr.me',
-        'ws://jgqaglhautb4k6e6i2g34jakxiemqp6z4wynlirltuukgkft2xuglmqd.onion'
+        'ws://jgqaglhautb4k6e6i2g34jakxiemqp6z4wynlirltuukgkft2xuglmqd.onion',
+        'wss://nostr-verified.wellorder.net'
       ],
       status: {}
     }


### PR DESCRIPTION
New relay that only accepts events from users with NIP-05 verified metadata.