### PR TITLE
add relay.minds.com

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,6 +23,7 @@ const App = {
         'wss://nostr.openchain.fr',
         'wss://nostr.delo.software',
         'wss://relay.nostr.info',
+        'wss://relay.minds.com/nostr/v1/ws'
       ],
       status: {}
     }


### PR DESCRIPTION
This PR adds the [minds.com](https://www.minds.com/) Nostr relay to the registry.

The relay is still in progress, for more info please see this repository:
https://gitlab.com/minds/infrastructure/nostr-relay
