### PR TITLE
Add nostr.developer.li public relay

### DIFF
--- a/relays.js
+++ b/relays.js
@@ -48,6 +48,7 @@ export const relays = [
   'wss://nostr.orangepill.dev',
   'wss://nostr.coollamer.com',
   'wss://nostr-relay.alekberg.net',
+  'wss://nostr.developer.li',
 ]
 
 shuffle(relays)


### PR DESCRIPTION
Relay located at [nostr.developer.li](https://nostr.developer.li).
General purpose public relay using [nostream](https://github.com/Cameri/nostream) v1.16.0.