### PR TITLE
Adding nostr.ro public relay

### DIFF
--- a/relays.js
+++ b/relays.js
@@ -48,6 +48,7 @@ export const relays = [
   'wss://nostr.orangepill.dev',
   'wss://nostr.coollamer.com',
   'wss://nostr-relay.alekberg.net',
+  'wss://relay.nostr.ro',
 ]
 
 shuffle(relays)


### PR DESCRIPTION
Link: https://relay.nostr.ro
Software: https://git.sr.ht/~gheartsfield/nostr-rs-relay
Version: 0.7.15